### PR TITLE
feature/headers

### DIFF
--- a/src/store/hub.js
+++ b/src/store/hub.js
@@ -22,7 +22,7 @@ function setAuthorizationHeader (accessToken) {
     axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`
     postMessage('updateAccessToken', { accessToken })
   } else {
-    delete axios.defaults.headers.Authorization
+    delete axios.defaults.headers.common.Authorization
   }
 }
 


### PR DESCRIPTION
## Problema
Encontramos em varios lugares dentro do sistema do CRM que o retorno de um erro ou ate mesmo de um patch estava dando um erro de CORS, depois de estudar muito, aparentemente era um "accept" que estava retornando com o valor `*/*` aonde deveria estar `application/json`

## Solução:
Ao verificar na documentação do axios como implementar o default do header, percebi que mesmo alterando ele na aplicação, ele não mudava no cenário real da aplicação, foi ai que fiz o teste trocando (ver o que mudou) e tudo passou a funcionar normalmente dentro da aplicação.
Creio que como ele trocava o default do axios na store, isso estava comprometendo outros elementos de dentro do headers

## Changelog
- changing headers call

LINKS:
[https://axios-http.com/docs/config_defaults](axios lib)

Obs.: Trocar ideia com o Leo e o Raul