### PR TITLE
Fix postMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
+## Não publicado
+### Corrigido
+- Adicionado import do `postMessage` no arquivo `mutations.js`, antes estava usando postMessage nativo do `window` e estava fugindo do padrão e não retornando o `user`.
+
 ## 3.1.1-beta.0 - 17-07-2023
 ### Corrigido
 - `auth-pinia.js`: corrigido função `can` que estava sendo usada sem importação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
 ## Não publicado
+## BREAKING CHANGES
+- Como estava vindo de forma errada o `updateUser`, é possível que na aplicação tenha que corrigir também para se adequar ao padrão correto.
+
 ### Corrigido
-- Adicionado import do `postMessage` no arquivo `mutations.js`, antes estava usando postMessage nativo do `window` e estava fugindo do padrão e não retornando o `user`.
+- Adicionado import do `postMessage` para o `updateUser` no arquivo `mutations.js`, antes estava usando postMessage nativo do `window` e estava fugindo do padrão e não retornando o `user`.
 
 ## 3.1.1-beta.0 - 17-07-2023
 ### Corrigido

--- a/README.md
+++ b/README.md
@@ -159,6 +159,23 @@ Esta extensão comunica-se apenas com a aplicação servidor diretamente ligada 
   })
   ```
 
+- Evento que retorna toda vez que o `user` é atualizado (users/me):
+  ```js
+  
+  window.addEventListener('message', ({ data }) => {
+    data.type // updateUser
+    data.user // user atualizado
+  })
+  ```
+
+- Evento que retorna toda vez que o `accessToken` é atualizado:
+  ```js
+  window.addEventListener('message', ({ data }) => {
+    data.type // updateAccessToken
+    data.accessToken // token atualizado
+  })
+  ```
+
 ## Funções
 
 Esta extensão também verifica se o usuário possui ou não permissões para visualizar o conteúdo com a função `$can`

--- a/src/helpers/mutations.js
+++ b/src/helpers/mutations.js
@@ -1,6 +1,7 @@
 import { LocalStorage } from 'quasar'
 import setAuthorizationHeader from './set-authorization-header.js'
 import { getStateFromAction } from '@bildvitta/store-adapter'
+import postMessage from './post-message.js'
 
 // mutations functions
 export function replaceAccessToken ({ accessToken = '', isPinia }) {


### PR DESCRIPTION
## BREAKING CHANGES
- Como estava vindo de forma errada o `updateUser`, é possível que na aplicação tenha que corrigir também para se adequar ao padrão correto.

### Corrigido
- Adicionado import do `postMessage` para o `updateUser` no arquivo `mutations.js`, antes estava usando postMessage nativo do `window` e estava fugindo do padrão e não retornando o `user`.
