### PR TITLE
Novo composable useAppCan

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/iron

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
-## 3.1.1-beta.4 - 13-12-2024
+## 3.1.1-beta.4 - 23-01-2025
+## BREAKING CHANGES
+- Necessário adicionar env `ME_VERSION` contendo 2 valores possíveis, `1|2`.
+
 ### Adicionado
 - Adicionado novo composable `useAppCan`.
 - Adicionado arquivo `.nvmrc`.
+- `store/hub/getUser`: adicionado query `version` no endpoint `GET -> users/me`, vindo da env `ME_VERSION`.
+- `store/hub/mutations/replaceUser`: adicionado company default dentro de `defaultFilters` no localStorage.
 
 ### Modificado
 - Atualizado biblioteca `@bildvitta/composables` para versão `1.0.0-beta.9`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versi
 
 ## 3.1.1-beta.4 - 23-01-2025
 ## BREAKING CHANGES
-- Necessário adicionar env `ME_VERSION` contendo 2 valores possíveis, `1|2`.
+- Necessário adicionar env `ME_VERSION` contendo 2 valores possíveis, `1|2`, 1 sendo o valor atual, e 2 para o novo /me.
 
 ### Adicionado
 - Adicionado novo composable `useAppCan`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
+## 3.1.1-beta.4 - 13-12-2024
+### Adicionado
+- Adicionado novo composable `useAppCan`.
+- Adicionado arquivo `.nvmrc`.
+
+### Modificado
+- Atualizado biblioteca `@bildvitta/composables` para versão `1.0.0-beta.9`.
+
 ## 3.1.1-beta.3 - 15-03-2024
 ### Corrigido
 - `use-can-pinia`: adicionado `.user` no `hubStore()`, para recuperar o usuário.

--- a/README.md
+++ b/README.md
@@ -202,21 +202,41 @@ Esta extensão comunica-se apenas com a aplicação servidor diretamente ligada 
   ```
 
 ## Composables
-É possível importar o composable `useCan` para utilizar com Composition API, existem 2 opções, para o pinia e para o vuex:
+É possível importar o composable `useCan` e `useAppCan` para utilizar com Composition API, existem 2 opções, para o pinia e para o vuex:
 
 ```js
-import { useCan } from 'hub/vuex'
+import { useCan, useAppCan } from 'hub/vuex'
 
 const { can, canAny } = useCan()
+
+const {
+  can,
+  canList,
+  canCreate,
+  canByPermission,
+  canEdit,
+  canDelete,
+  canShow
+} = useAppCan()
 ```
 
 ```js
 import { useCan } from 'hub/pinia'
 
-const { can, canAny } = useCan()
+const { can, canAny, useAppCan } = useCan()
+
+const {
+  can,
+  canList,
+  canCreate,
+  canByPermission,
+  canEdit,
+  canDelete,
+  canShow
+} = useAppCan()
 ```
 
-## Funções
+## Funções globais
 
 Esta extensão também verifica se o usuário possui ou não permissões para visualizar o conteúdo com a função `$can`
 A função verifica no retorno do usuário logado, se ele possui ou não privilégios atrelados à chamada do `/me` salvo na storage
@@ -233,6 +253,26 @@ ex. 2: `$can('realState.show`, realStateId)` -> Verifica se o usuário possui pe
 Obs.: Caso o usuário tenha permissões de verificar `todas as entidades`, ele terá um wildcard `*`.
 Obs. 2: Essa função também verifica se o usuário é superuser, caso positivo, ira retornar sempre `true`
 
+**Observação importante:**
+Não existe uma função global para o composable `useAppCan`, para isto, quando utilizado em options api, continue utilizando o composale, exemplo:
+```js
+import { useAppCan } from 'hub/vuex'
+
+export default {
+  name: 'XPTO',
+
+  data () {
+    permission: useAppCan()
+  },
+
+  created () {
+    ...
+
+    if (this.permission.canList('xpto')) ...
+  }
+}
+```
+
 ## Contribuindo
 
 Com este repositório em sua máquina, basta instalar a extensão apontando o diretório local de dentro de uma aplicação Quasar, por exemplo:
@@ -244,5 +284,5 @@ $ npm i -D file://../quasar-app-extension-hub
 Ainda que dispensável para esta extensão, você pode invocar o arquivo de instalação executando o comando:
 
 ```bash
-$ quasar ext invoke @bildvitta/hub  
+$ quasar ext invoke @bildvitta/hub
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ module.exports = {
 
 Lembrando que este arquivo não é obrigatório sendo possível utilizar somente para alterar configurações especificas como por exemplo usar apenas para alterar o `storeAdapter`.
 
+Após isto adicione caso não exista a env `ME_VERSION` no arquivo `quasar.config.js` com os possíveis valores `1|2`, sendo number.
+
 ### Dica
 O path `'hub'` quando utilizado para importação `import { ... } from 'hub/vuex'` ou `import { ... } from 'hub/pinia'` é criado via alias, então é perdido todo o autocomplete/intellisense do vscode, para contornar isto, dentro do `jsconfig.json`, adicione:
 
@@ -150,7 +152,7 @@ Esta extensão comunica-se apenas com a aplicação servidor diretamente ligada 
 
 | Endpoint | Método | Parâmetros | Retorno | Descrição |
 |----------|--------|------------|---------|-----------|
-| `/users/me` | `GET` | | `{ user: { ... } }` | Busca os dados do usuário autenticado. |
+| `/users/me?version={process.env.ME_VERSION}` | `GET` | | `{ user: { ... } }` | Busca os dados do usuário autenticado. |
 | `/auth/callback` | `GET` | `code` e `state`: Chaves do Hub. | `{ accessToken: '...' }` | Irá retornar o JWT. |
 | `/auth/login` | `GET` | `url`: Endereço de _callback_. | `{ loginUrl: '...' }` | Busca o endereço de autenticação. |
 | `/auth/logout` | `GET` | `url`: Endereço de _callback_. | `{ logoutUrl: '...' }` | Busca o endereço de desconexão. |
@@ -254,7 +256,7 @@ Obs.: Caso o usuário tenha permissões de verificar `todas as entidades`, ele t
 Obs. 2: Essa função também verifica se o usuário é superuser, caso positivo, ira retornar sempre `true`
 
 **Observação importante:**
-Não existe uma função global para o composable `useAppCan`, para isto, quando utilizado em options api, continue utilizando o composale, exemplo:
+Não existe uma função global para o composable `useAppCan`, para isto, quando utilizado em options api, continue utilizando o composable, exemplo:
 ```js
 import { useAppCan } from 'hub/vuex'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.1-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@bildvitta/composables": "^1.0.0-beta.7",
+        "@bildvitta/composables": "^1.0.0-beta.9",
         "@bildvitta/store-adapter": "^1.0.0"
       }
     },
@@ -25,14 +25,16 @@
       }
     },
     "node_modules/@bildvitta/composables": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
-      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.9.tgz",
+      "integrity": "sha512-xdeDkcFI8r2a0SV8j4TvEc62RNVd8XrXP5WVs2/7fSTVSwVgbuUGsPLiogcwMaZYDCbu8rqPRZoqoEMEGpt29w==",
       "dependencies": {
         "@vue/compiler-sfc": "^3.4.21",
         "path": "^0.12.7",
-        "vue": "^3.4.21",
         "vue-demi": "^0.14.7"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/@bildvitta/store-adapter": {
@@ -620,6 +622,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
       "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
+      "peer": true,
       "dependencies": {
         "@vue/shared": "3.4.21"
       }
@@ -628,6 +631,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
       "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -637,6 +641,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
       "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
+      "peer": true,
       "dependencies": {
         "@vue/runtime-core": "3.4.21",
         "@vue/shared": "3.4.21",
@@ -647,6 +652,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
       "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -774,7 +780,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1541,6 +1548,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
       "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.4.21",
         "@vue/compiler-sfc": "3.4.21",
@@ -1614,13 +1622,12 @@
       "integrity": "sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg=="
     },
     "@bildvitta/composables": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.7.tgz",
-      "integrity": "sha512-LV7GL8w3PE1xYb/z52RoVZn1N+SS1pneqtiJDnMPquBKSBxYgFBoBr4/N4A4gLKIF3B/JRYmUbGLUYaRpL2PVg==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@bildvitta/composables/-/composables-1.0.0-beta.9.tgz",
+      "integrity": "sha512-xdeDkcFI8r2a0SV8j4TvEc62RNVd8XrXP5WVs2/7fSTVSwVgbuUGsPLiogcwMaZYDCbu8rqPRZoqoEMEGpt29w==",
       "requires": {
         "@vue/compiler-sfc": "^3.4.21",
         "path": "^0.12.7",
-        "vue": "^3.4.21",
         "vue-demi": "^0.14.7"
       }
     },
@@ -1997,6 +2004,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
       "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
+      "peer": true,
       "requires": {
         "@vue/shared": "3.4.21"
       }
@@ -2005,6 +2013,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
       "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
+      "peer": true,
       "requires": {
         "@vue/reactivity": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -2014,6 +2023,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
       "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
+      "peer": true,
       "requires": {
         "@vue/runtime-core": "3.4.21",
         "@vue/shared": "3.4.21",
@@ -2024,6 +2034,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
       "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
+      "peer": true,
       "requires": {
         "@vue/compiler-ssr": "3.4.21",
         "@vue/shared": "3.4.21"
@@ -2123,7 +2134,8 @@
     "csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "peer": true
     },
     "debug": {
       "version": "4.3.4",
@@ -2630,6 +2642,7 @@
       "version": "3.4.21",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
       "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
+      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.4.21",
         "@vue/compiler-sfc": "3.4.21",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/bildvitta/quasar-app-extension-hub#readme",
   "dependencies": {
-    "@bildvitta/composables": "^1.0.0-beta.7",
+    "@bildvitta/composables": "^1.0.0-beta.9",
     "@bildvitta/store-adapter": "^1.0.0"
   }
 }

--- a/src/boot/auth-pinia.js
+++ b/src/boot/auth-pinia.js
@@ -1,6 +1,5 @@
 import piniaHubStore from '../store/pinia-hub-store.js'
 import { DefineGlobalPiniaStore } from '@bildvitta/store-adapter'
-
 import can from '../helpers/can.js'
 
 import {

--- a/src/composables/use-app-can-pinia.js
+++ b/src/composables/use-app-can-pinia.js
@@ -1,0 +1,43 @@
+import hubStore from '../store/pinia-hub-store'
+
+import { useAppCanWrapper } from '@bildvitta/composables'
+
+/**
+ * @desc Composable base para permissionamento de tela v2.
+ *
+ * ```js
+ * const {
+ *  can,
+ *  canList,
+ *  canCreate,
+ *  canByPermission,
+ *  canEdit,
+ *  canDelete,
+ *  canShow
+ * } = useAppCan()
+ *
+ * can('users', { action: 'dashboard' })
+ * can({ users: { action: 'dashboard' } })
+ *
+ * canList('users')
+ * canList(['users', 'approvals'])
+ *
+ * canCreate('users')
+ * canCreate(['users', 'approvals'])
+ *
+ * canByPermission('users', { company: 'company1', action: 'dashboard' })
+ * canByPermission({ users: { company: ['company1', 'company2'], action: 'dashboard' } })
+ *
+ * canEdit('users', { company: ['company1', 'company2'] })
+ * canEdit({ users: { company: 'company1' } })
+ *
+ * canDelete('users', { company: 'company1' })
+ * canDelete({ users: { company: ['company1', 'company2'] } })
+ *
+ * canShow('users', { company: 'company1' })
+ * canShow({ users: { company: ['company1', 'company2'] } })
+ * ```
+ */
+export default function () {
+  return useAppCanWrapper({ store: hubStore().user })
+}

--- a/src/composables/use-app-can-vuex.js
+++ b/src/composables/use-app-can-vuex.js
@@ -1,0 +1,42 @@
+import { useStore } from 'vuex'
+import { useAppCanWrapper } from '@bildvitta/composables'
+
+/**
+ * @desc Composable base para permissionamento de tela v2.
+ *
+ * ```js
+ * const {
+ *  can,
+ *  canList,
+ *  canCreate,
+ *  canByPermission,
+ *  canEdit,
+ *  canDelete,
+ *  canShow
+ * } = useAppCan()
+ *
+ * can('users', { action: 'dashboard' })
+ * can({ users: { action: 'dashboard' } })
+ *
+ * canList('users')
+ * canList(['users', 'approvals'])
+ *
+ * canCreate('users')
+ * canCreate(['users', 'approvals'])
+ *
+ * canByPermission('users', { company: 'company1', action: 'dashboard' })
+ * canByPermission({ users: { company: ['company1', 'company2'], action: 'dashboard' } })
+ *
+ * canEdit('users', { company: ['company1', 'company2'] })
+ * canEdit({ users: { company: 'company1' } })
+ *
+ * canDelete('users', { company: 'company1' })
+ * canDelete({ users: { company: ['company1', 'company2'] } })
+ *
+ * canShow('users', { company: 'company1' })
+ * canShow({ users: { company: ['company1', 'company2'] } })
+ * ```
+ */
+export default function () {
+  return useAppCanWrapper({ store: useStore().state.hub.user })
+}

--- a/src/globals/pinia/index.js
+++ b/src/globals/pinia/index.js
@@ -1,2 +1,3 @@
 export { default as hubStore } from '../../store/pinia-hub-store'
 export { default as useCan } from '../../composables/use-can-pinia'
+export { default as useAppCan } from '../../composables/use-app-can-pinia'

--- a/src/globals/vuex/index.js
+++ b/src/globals/vuex/index.js
@@ -1,1 +1,2 @@
 export { default as useCan } from '../../composables/use-can-vuex'
+export { default as useAppCan } from '../../composables/use-app-can-vuex'

--- a/src/helpers/mutations.js
+++ b/src/helpers/mutations.js
@@ -19,4 +19,27 @@ export function replaceUser ({ user = {}, isPinia }) {
   state.user = user
 
   postMessage('updateUser', { user })
+
+  setDefaultFiltersInStorage(user)
+
+  /**
+   * Se existe a propriedade "currentMainCompany" no usuário, então é feito uma busca
+   * no array de "companyLinksOptions" para encontrar o valor correspondente e setar
+   * como valor padrão para o filtro de empresa, caso não encontre ou então não exista a
+   * propriedade "currentMainCompany", então é setado o primeiro valor do array de "companyLinksOptions".
+   */
+  function setDefaultFiltersInStorage (user) {
+    const defaultFiltersFromStorage = LocalStorage.getItem('defaultFilters') || {}
+
+    const firstCompanyLinkOptionValue = user.companyLinksOptions.at(0)?.value
+
+    const defaultCompany = user.currentMainCompany
+      ? user.companyLinksOptions.find(({ value }) => value === user.currentMainCompany)?.value || firstCompanyLinkOptionValue
+      : firstCompanyLinkOptionValue
+
+    LocalStorage.set('defaultFilters', {
+      ...defaultFiltersFromStorage,
+      company: defaultCompany
+    })
+  }
 }

--- a/src/store/hub.js
+++ b/src/store/hub.js
@@ -1,11 +1,12 @@
-import axios from 'axios'
 import setAuthorizationHeader from '../helpers/set-authorization-header'
 import setMessageEvent from '../helpers/set-message-event'
-import { LocalStorage } from 'quasar'
 import { hasString } from '../helpers/string'
 import { replaceAccessToken, replaceUser } from '../helpers/mutations'
 import { getActionPayload } from '@bildvitta/store-adapter'
 import hubConfig from '../shared/default-hub-config.js'
+
+import axios from 'axios'
+import { LocalStorage } from 'quasar'
 
 const { storeAdapter } = hubConfig
 const isPinia = storeAdapter === 'pinia'
@@ -52,7 +53,11 @@ const actions = {
 
   async getUser () {
     try {
-      const { data } = await axios.get('/users/me')
+      const { data } = await axios.get('/users/me', {
+        params: {
+          version: process.env.ME_VERSION
+        }
+      })
 
       replaceUser.call(this, { user: data.result, isPinia })
       return data.result


### PR DESCRIPTION
## 3.1.1-beta.4 - 23-01-2025
## BREAKING CHANGES
- Necessário adicionar env `ME_VERSION` contendo 2 valores possíveis, `1|2`.

### Adicionado
- Adicionado novo composable `useAppCan`.
- Adicionado arquivo `.nvmrc`.
- `store/hub/getUser`: adicionado query `version` no endpoint `GET -> users/me`, vindo da env `ME_VERSION`.
- `store/hub/mutations/replaceUser`: adicionado company default dentro de `defaultFilters` no localStorage.

### Modificado
- Atualizado biblioteca `@bildvitta/composables` para versão `1.0.0-beta.9`.