### PR TITLE
Resetar local storage e session storage ao deslogar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em Keep a Changelog, e este projeto adere ao Semantic Versioning.
 
+## Não publicado
+### Adicionado
+- `HubLogout`: adicionado função para limpar todo local storage e session storage.
+
+### Corrigido
+- `helpers/mutations`: corrigido função `setDefaultFiltersInStorage` que dava erro quando não existia o user a primeira vez.
+
 ## 3.1.1-beta.4 - 23-01-2025
 ## BREAKING CHANGES
 - Necessário adicionar env `ME_VERSION` contendo 2 valores possíveis, `1|2`, 1 sendo o valor atual, e 2 para o novo /me.

--- a/src/helpers/mutations.js
+++ b/src/helpers/mutations.js
@@ -28,10 +28,10 @@ export function replaceUser ({ user = {}, isPinia }) {
    * como valor padrão para o filtro de empresa, caso não encontre ou então não exista a
    * propriedade "currentMainCompany", então é setado o primeiro valor do array de "companyLinksOptions".
    */
-  function setDefaultFiltersInStorage (user) {
+  function setDefaultFiltersInStorage (user = {}) {
     const defaultFiltersFromStorage = LocalStorage.getItem('defaultFilters') || {}
 
-    const firstCompanyLinkOptionValue = user.companyLinksOptions.at(0)?.value
+    const firstCompanyLinkOptionValue = user.companyLinksOptions?.at(0)?.value
 
     const defaultCompany = user.currentMainCompany
       ? user.companyLinksOptions.find(({ value }) => value === user.currentMainCompany)?.value || firstCompanyLinkOptionValue

--- a/src/pages/hub/HubLogout.vue
+++ b/src/pages/hub/HubLogout.vue
@@ -60,12 +60,22 @@ export default {
           key: 'clear'
         })
 
+        this.clearStorage()
+
         location.href = url
       } catch {
         this.hasError = true
       } finally {
         Loading.hide()
       }
+    },
+
+    /**
+     * Limpa o localStorage e sessionStorage, removendo todos os dados armazenados.
+     */
+    clearStorage () {
+      localStorage.clear()
+      sessionStorage.clear()
     }
   }
 }


### PR DESCRIPTION
## Não publicado
### Adicionado
- `HubLogout`: adicionado função para limpar todo local storage e session storage.

### Corrigido
- `helpers/mutations`: corrigido função `setDefaultFiltersInStorage` que dava erro quando não existia o user a primeira vez.
